### PR TITLE
feed header PreserveAspectFit fill mode

### DIFF
--- a/qml/components/FeedHeader.qml
+++ b/qml/components/FeedHeader.qml
@@ -30,6 +30,7 @@ Rectangle {
         sourceSize.height: height
 
         anchors.centerIn: feedHeader
+        fillMode: Image.PreserveAspectFit
 
         MouseArea{
             anchors.fill: parent


### PR DESCRIPTION
I guess it makes sense to add this fill mode for the header. Found this issue with xiaomi kenzo port. But it's your fork so you decide which fill mode fits better ;)

![before](http://i.imgur.com/4VOykTd.png)

![after](http://i.imgur.com/CWKK1h4.png)